### PR TITLE
Support for token, storage url and auth version options closes #5

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func main() {
 	flag.StringVar(&sc.AuthUrl, "a", "https://auth.cloud.ovh.net/v2.0", "Authentication URL")
 	flag.StringVar(&sc.Region, "r", "", "Region")
 	flag.StringVar(&sc.Tenant, "t", "", "Tenant name")
+	flag.StringVar(&sc.StorageUrl, "s", "", "Storage URL")
+	flag.StringVar(&sc.AuthToken, "k", "", "Authentication token")
+	flag.IntVar(&sc.AuthVersion, "v", 0, "Authentication version")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s :\n", os.Args[0])
 		flag.PrintDefaults()
@@ -55,8 +58,11 @@ func main() {
 	defer c.Close()
 
 	// Pre-Serve: authenticate to identity endpoint
-	if err = sc.Authenticate(); err != nil {
-		goto Err
+	// if no token is specified
+	if !sc.Authenticated() {
+		if err = sc.Authenticate(); err != nil {
+			goto Err
+		}
 	}
 
 	// Init SVFS

--- a/svfs/fs.go
+++ b/svfs/fs.go
@@ -12,7 +12,10 @@ type SVFS struct {
 
 func (s *SVFS) Init(sc *swift.Connection) error {
 	s.s = sc
-	return s.s.Authenticate()
+	if !s.s.Authenticated() {
+		return s.s.Authenticate()
+	}
+	return nil
 }
 
 func (s *SVFS) Root() (fs.Node, error) {


### PR DESCRIPTION
This brings support for already authenticated users that want to use their credentials, and solutions like hubiC.