### PR TITLE
Bugfix: kernel cache invalidation leads to ENOENT in lookup calls

### DIFF
--- a/svfs/directory.go
+++ b/svfs/directory.go
@@ -147,6 +147,12 @@ func (d *Directory) ReadDirAll(ctx context.Context) (entries []fuse.Dirent, err 
 }
 
 func (d *Directory) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (fs.Node, error) {
+	// Get children if this node was evicted from the kernel cache
+	if len(d.children) == 0 {
+		d.ReadDirAll(ctx)
+	}
+
+	// Find matching child
 	for _, item := range d.children {
 		if item.Name() == req.Name {
 			if n, ok := item.(*Container); ok {
@@ -160,6 +166,7 @@ func (d *Directory) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *f
 			}
 		}
 	}
+
 	return nil, fuse.ENOENT
 }
 


### PR DESCRIPTION
As described in #7, this can be obeserved when entry is no more considered valid by the kernel thus leading to forgetting children nodes inside a directory.

This is fixed by checking the children count before finding a matching node by name in lookup calls.